### PR TITLE
Update base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.15.6-alpine
 
 COPY pod-reaper /pod-reaper
 CMD  /pod-reaper


### PR DESCRIPTION
[Golang doesn't officially support the 1.13 images any more](https://hub.docker.com/_/golang). This PR updates the base image to the most recent stable release.