### PR TITLE
Update base image to supported version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.4-alpine
+FROM golang:1.15.6-alpine
 
 RUN apk --no-cache add curl git && curl https://glide.sh/get | sh && apk del curl
 


### PR DESCRIPTION
[Golang doesn't officially support the 1.13 images any more](https://hub.docker.com/_/golang). This PR updates the base image to the most recent stable release.